### PR TITLE
Work for 3 February 2025

### DIFF
--- a/javascript-simplified/beginner-course/Section 11 - Bonus Projects/1-tooltip-library/typescript-tooltip-library/index.html
+++ b/javascript-simplified/beginner-course/Section 11 - Bonus Projects/1-tooltip-library/typescript-tooltip-library/index.html
@@ -11,7 +11,7 @@
 </head>
 <body>
   <div class="container x-center y-center" data-container>
-    <span class="help-text" data-spacing="10" data-positions="top_left|top_right|bottom_left|bottom_right"
+    <span class="help-text" data-positions="top|bottom|top_left|top_right|bottom_left|bottom_right"
       data-tooltip="Lorem ipsum dolor, sit amet. asdf asdf asd fasdf asdf asd fasd fasd f">Hover
       Me.</span>
   </div>

--- a/javascript-simplified/beginner-course/Section 11 - Bonus Projects/1-tooltip-library/typescript-tooltip-library/src/styles.css
+++ b/javascript-simplified/beginner-course/Section 11 - Bonus Projects/1-tooltip-library/typescript-tooltip-library/src/styles.css
@@ -54,11 +54,59 @@ body {
 }
 
 .tooltip {
+	--border-color: black;
+	--background-color: white;
+	--arrow-size: 10px;
+	--arrow-top: 0px;
+	--arrow-left: 0px;
 	position: absolute;
 	padding: 0.4rem;
-	border: 1px solid black;
+	border: 1px solid var(--border-color);
 	border-radius: 0.25rem;
 	font-size: 0.75rem;
 	max-width: 200px;
 	user-select: none;
+	background-color: var(--background-color);
+
+	&::before,
+	&::after {
+		content: "";
+		display: block;
+		position: absolute;
+		width: 0;
+		height: 0;
+	}
+
+	&::before {
+		border: var(--arrow-size) solid;
+		left: calc(var(--arrow-left) - 1px);
+	}
+	&::after {
+		border: calc(var(--arrow-size) - 1px) solid;
+		left: var(--arrow-left);
+	}
+
+	&.arrow-top {
+		&::before,
+		&::after {
+			top: calc(var(--arrow-top) - 2px);
+		}
+		&::before {
+			border-color: var(--border-color) transparent transparent;
+		}
+		&::after {
+			border-color: var(--background-color) transparent transparent;
+		}
+	}
+
+	&.arrow-bottom {
+		&::before {
+			border-color: transparent transparent var(--border-color);
+			top: var(--arrow-top);
+		}
+		&::after {
+			border-color: transparent transparent var(--background-color);
+			top: calc(var(--arrow-top) + 2px);
+		}
+	}
 }


### PR DESCRIPTION
- add the bottom-left and bottom-right positions
- add an arrow to the top and bottom positions
- make the arrow size be controlled by the space between the element and the tooltip; this inherently allows the arrow size to be overridden by a data attribute since the spacing can already be overridden by a data attribute