### PR TITLE
Work for 7 February 2025

### DIFF
--- a/javascript-simplified/beginner-course/Section 10 - Modules and Bundlers/74-shopping-cart/typescript-shopping-cart/src/cart.ts
+++ b/javascript-simplified/beginner-course/Section 10 - Modules and Bundlers/74-shopping-cart/typescript-shopping-cart/src/cart.ts
@@ -165,9 +165,10 @@ const compactCartItemTemplate = cartElement.querySelector(
 ) as HTMLTemplateElement
 function renderCartItem(item: Item, quantity: CartItemQuantity, useCompactView: boolean) {
 	// once the compact item template is complete, this should decide which template to use based on useCompactView
-	const cartItemElement = (
+	const fragment = (
 		useCompactView ? compactCartItemTemplate : fullCartItemTemplate
-	).content.cloneNode(true) as HTMLDivElement
+	).content.cloneNode(true) as DocumentFragment
+	const cartItemElement = fragment.children[0] as HTMLDivElement
 
 	const image = cartItemElement.querySelector(
 		"[data-cart-item-image]"

--- a/javascript-simplified/beginner-course/Section 11 - Bonus Projects/2-trello-clone/typescript-trello-clone/index.html
+++ b/javascript-simplified/beginner-course/Section 11 - Bonus Projects/2-trello-clone/typescript-trello-clone/index.html
@@ -35,7 +35,7 @@
     </div>
   </header>
   <!-- TODO: Pull in the new item form placeholder and use it when creating each group. -->
-  <div class="groups" data-item-form-placeholder="Task Name">
+  <div class="groups" data-item-form-placeholder="Task Name" data-tooltip-observe>
     <div class="group">
       <div class="group-header">
         <span data-name>Backlog</span>
@@ -90,16 +90,15 @@
           </svg>
         </button>
       </div>
-      <div class="items" data-drop-zone data-group-id=""></div>
+      <div class="items" data-drop-zone data-tooltip-observe></div>
       <form data-item-form>
         <input type="text" class="item-input" placeholder="Item Name" data-item-input>
       </form>
     </div>
   </template>
-  <!-- TODO: Make item element creation use this instead of creating everything in JavaScript. -->
   <template data-item-template>
     <div class="item" data-draggable>
-      <div data-item-name></div>
+      <div data-item-text></div>
       <button class="icon-button" data-delete-item-button data-tooltip="Delete item">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
           <use href="#close"></use>

--- a/javascript-simplified/beginner-course/Section 11 - Bonus Projects/2-trello-clone/typescript-trello-clone/src/styles.css
+++ b/javascript-simplified/beginner-course/Section 11 - Bonus Projects/2-trello-clone/typescript-trello-clone/src/styles.css
@@ -127,8 +127,9 @@ header {
 	text-align: center;
 	word-wrap: break-word;
 
-	[data-item-name] {
+	[data-item-text] {
 		grid-column-start: 2;
+		pointer-events: none;
 	}
 
 	[data-delete-item-button] {


### PR DESCRIPTION
- fix the shopping cart project to actually pull the cart item element out of the document fragment created when cloning the template
- add a mutation observer to the tooltip in the trello clone so the tooltip is properly removed from the document in the case that the target element is deleted before the mouseleave event is triggered
- reorganize the trello clone typescript slightly to group related things together
- convert item element creation to use a template element as the basis instead of creating everything in typescript
- add the ability to delete an item
- start preparing for groups to be created dynamically instead of hard-coded